### PR TITLE
feat: ダッシュボード追加

### DIFF
--- a/src/app/components/drawer/StudentDrawer.tsx
+++ b/src/app/components/drawer/StudentDrawer.tsx
@@ -32,13 +32,6 @@ export const StudentDrawer = ({ isOpen, drawerWidth, setIsOpen }: Props) => {
 			url: 'top',
 		},
 		{
-			text: '教科',
-		},
-		{
-			text: '教科一覧',
-			url: 'subject_list',
-		},
-		{
 			text: '課題',
 		},
 		{

--- a/src/app/components/drawer/TeacherDrawer.tsx
+++ b/src/app/components/drawer/TeacherDrawer.tsx
@@ -101,6 +101,7 @@ export const TeacherDrawer = ({ isOpen, drawerWidth, setIsOpen }: Props) => {
 									width: '100%',
 									padding: '10px 15px',
 								}}
+								prefetch={true}
 							>
 								<ListItemText
 									primary={item.text}

--- a/src/app/student/portal/top/_components/CardContents.tsx
+++ b/src/app/student/portal/top/_components/CardContents.tsx
@@ -1,0 +1,55 @@
+'use client'
+import { Box, Paper, SvgIconTypeMap } from '@mui/material'
+import { OverridableComponent } from '@mui/material/OverridableComponent'
+import Link from 'next/link'
+
+interface Props {
+	title: string
+	icon: OverridableComponent<SvgIconTypeMap<{}, 'svg'>> & {
+		muiName: string
+	}
+	url: string
+}
+
+export const CardContents = (props: Props) => {
+	return (
+		<Link
+			href={`/student/portal/${props.url}`}
+			style={{
+				width: 'fit-content',
+				textDecoration: 'none',
+			}}
+			prefetch={true}
+		>
+			<Paper
+				sx={{
+					width: '100px',
+					padding: '10px',
+				}}
+			>
+				<Box
+					sx={{
+						display: 'flex',
+						flexDirection: 'column',
+						alignItems: 'center',
+					}}
+				>
+					<Box
+						sx={{
+							fontSize: '24px',
+						}}
+					>
+						<props.icon
+							sx={{
+								fontSize: '50px',
+							}}
+						/>
+					</Box>
+					<Box>
+						<Box>{props.title}</Box>
+					</Box>
+				</Box>
+			</Paper>
+		</Link>
+	)
+}

--- a/src/app/student/portal/top/_components/Top.tsx
+++ b/src/app/student/portal/top/_components/Top.tsx
@@ -1,5 +1,17 @@
+import { options } from '@/app/options'
+import { IssueCoverStatusCount } from '@/types/api-response-types'
+import { getServerSession } from 'next-auth'
 import { TopContents } from './TopContents'
 
 export default async function Top() {
-	return <TopContents />
+	const session = await getServerSession(options)
+	const res = await fetch(`${process.env.API_URL}/api/issue/cover/count`, {
+		method: 'GET',
+		headers: {
+			'Content-Type': 'application/json',
+			Authorization: `Bearer ${session?.user.accessToken}`,
+		},
+	})
+	const issueCount: IssueCoverStatusCount = await res.json()
+	return <TopContents count={issueCount} />
 }

--- a/src/app/student/portal/top/_components/TopContents.tsx
+++ b/src/app/student/portal/top/_components/TopContents.tsx
@@ -1,71 +1,227 @@
-import { Box, Paper, Typography } from '@mui/material'
+'use client'
+import Box from '@mui/material/Box'
+import ManageHistoryIcon from '@mui/icons-material/ManageHistory'
+import PublishIcon from '@mui/icons-material/Publish'
+import { CardContents } from './CardContents'
+import { IssueCoverStatusCount } from '@/types/api-response-types'
+import SummarizeIcon from '@mui/icons-material/Summarize'
+import CheckCircleIcon from '@mui/icons-material/CheckCircle'
+import AnnouncementIcon from '@mui/icons-material/Announcement'
+import ErrorIcon from '@mui/icons-material/Error'
+import PendingIcon from '@mui/icons-material/Pending'
+import CheckCircleOutlineIcon from '@mui/icons-material/CheckCircleOutline'
+import { Paper, useTheme } from '@mui/material'
 
-const menuItems = ['教科一覧', '課題表紙提出', '提出状況']
-const statusDetails = [
-	{ title: '課題承認率', value: '81%' },
-	{ title: '承認数/課題数', value: '9/11' },
-	{ title: '承認待ち', value: '1' },
-	{ title: '再提出数', value: '0' },
-	{ title: '未提出数', value: '1' },
+const assignmentCardContents = [
+	{
+		title: '課題表紙提出',
+		icon: PublishIcon,
+		url: 'submit_assignment',
+	},
+	{
+		title: '提出状況',
+		icon: ManageHistoryIcon,
+		url: 'submission_status',
+	},
 ]
-export const TopContents = () => {
+interface Props {
+	count: IssueCoverStatusCount
+}
+
+export const TopContents = ({ count }: Props) => {
+	const notSubmittedCount =
+		count.issue_cover_status_count.total -
+		Object.entries(count.issue_cover_status_count).reduce(
+			(acc, [key, value]) => (key === 'total' ? acc : acc + value),
+			0,
+		)
+
+	const approvedCount = count.issue_cover_status_count.approved ?? 0
+	const exemptionCount = count.issue_cover_status_count.exemption ?? 0
+	const resubmissionCount = count.issue_cover_status_count.resubmission ?? 0
+	const pendingCount = count.issue_cover_status_count.pending ?? 0
+	const latePendingCount = count.issue_cover_status_count.late_pending ?? 0
+	const pendingExemptionCount = count.issue_cover_status_count.pending_exemption ?? 0
+	const pendingExemptionApprovalCount =
+		count.issue_cover_status_count.pending_exemption_approval ?? 0
+
+	const theme = useTheme()
 	return (
 		<Box>
 			<Box
 				sx={{
-					display: 'flex',
-					justifyContent: 'center',
-					flexWrap: 'wrap',
-					mt: '20px',
-					gap: '100px',
-					marginBottom: '50px',
+					fontSize: '20px',
+					py: '10px',
+					[theme.breakpoints.down('sm')]: {
+						textAlign: 'center',
+					},
 				}}
 			>
-				{menuItems.map((item) => (
-					<Paper
-						key={item}
-						sx={{
-							width: '279px',
-							height: '244px',
-							display: 'flex',
-							alignItems: 'center',
-							justifyContent: 'center',
-							boxShadow: '0px 4px 4px rgba(0, 0, 0, 0.25)',
-							cursor: 'pointer',
-						}}
-					>
-						<Typography>{item}</Typography>
-					</Paper>
+				課題表紙作業
+			</Box>
+			<Box
+				sx={{
+					display: 'flex',
+					flexWrap: 'wrap',
+					gap: '10px',
+					[theme.breakpoints.down('sm')]: {
+						justifyContent: 'center',
+					},
+				}}
+			>
+				{assignmentCardContents.map((content, index) => (
+					<CardContents key={index} {...content} />
 				))}
 			</Box>
-			<Paper
+			<Box
 				sx={{
-					background: '#fff',
-					boxShadow: '0px 4px 4px rgba(0, 0, 0, 0.25)',
-					maxWidth: '1091px',
-					margin: '0 auto',
-					paddingBottom: '30px',
+					fontSize: '20px',
+					py: '10px',
+					[theme.breakpoints.down('sm')]: {
+						textAlign: 'center',
+					},
 				}}
 			>
-				<Box sx={{ padding: '6px', borderBottom: 1, borderColor: 'divider' }}>
-					<Typography variant='h6'>課題提出ステータス</Typography>
-				</Box>
-				<Box
+				提出状況
+			</Box>
+			<Box
+				sx={{
+					display: 'flex',
+					flexDirection: 'row',
+					alignItems: 'center',
+					flexWrap: 'wrap',
+					gap: '10px',
+					[theme.breakpoints.down('sm')]: {
+						justifyContent: 'center',
+					},
+				}}
+			>
+				<Paper
 					sx={{
+						padding: '10px',
 						display: 'flex',
-						justifyContent: 'space-evenly',
-						flexWrap: 'wrap',
-						padding: '20px',
+						flexDirection: 'column',
+						alignItems: 'center',
 					}}
 				>
-					{statusDetails.map(({ title, value }) => (
-						<Box key={title} sx={{ width: '202px', textAlign: 'center', margin: '10px' }}>
-							<Typography variant='subtitle1'>{title}</Typography>
-							<Typography variant='h6'>{value}</Typography>
-						</Box>
-					))}
-				</Box>
-			</Paper>
+					<Box>
+						<SummarizeIcon
+							sx={{
+								fontSize: '50px',
+							}}
+						/>
+					</Box>
+					<Box>
+						課題承認率:{' '}
+						{Math.floor(
+							((approvedCount + exemptionCount) / count.issue_cover_status_count.total) * 100,
+						)}
+						%
+					</Box>
+				</Paper>
+				<Paper
+					sx={{
+						padding: '10px',
+						display: 'flex',
+						flexDirection: 'column',
+						alignItems: 'center',
+					}}
+				>
+					<Box>
+						<CheckCircleIcon
+							sx={{
+								fontSize: '50px',
+							}}
+						/>
+					</Box>
+					<Box>承認済: {approvedCount}件</Box>
+				</Paper>
+				<Paper
+					sx={{
+						padding: '10px',
+						display: 'flex',
+						flexDirection: 'column',
+						alignItems: 'center',
+					}}
+				>
+					<Box>
+						<PendingIcon
+							sx={{
+								fontSize: '50px',
+							}}
+						/>
+					</Box>
+					<Box>承認待ち: {pendingCount + latePendingCount}件</Box>
+				</Paper>
+				<Paper
+					sx={{
+						padding: '10px',
+						display: 'flex',
+						flexDirection: 'column',
+						alignItems: 'center',
+					}}
+				>
+					<Box>
+						<AnnouncementIcon
+							sx={{
+								fontSize: '50px',
+							}}
+						/>
+					</Box>
+					<Box>未提出: {notSubmittedCount}件</Box>
+				</Paper>
+				<Paper
+					sx={{
+						padding: '10px',
+						display: 'flex',
+						flexDirection: 'column',
+						alignItems: 'center',
+					}}
+				>
+					<Box>
+						<ErrorIcon
+							sx={{
+								fontSize: '50px',
+							}}
+						/>
+					</Box>
+					<Box>再提出: {resubmissionCount}件</Box>
+				</Paper>
+				<Paper
+					sx={{
+						padding: '10px',
+						display: 'flex',
+						flexDirection: 'column',
+						alignItems: 'center',
+					}}
+				>
+					<Box>
+						<CheckCircleOutlineIcon
+							sx={{
+								fontSize: '50px',
+							}}
+						/>
+					</Box>
+					<Box>免除済み: {exemptionCount}件</Box>
+				</Paper>
+				<Paper
+					sx={{
+						padding: '10px',
+						display: 'flex',
+						flexDirection: 'column',
+						alignItems: 'center',
+					}}
+				>
+					<Box>
+						<PendingIcon
+							sx={{
+								fontSize: '50px',
+							}}
+						/>
+					</Box>
+					<Box>免除手続き中: {pendingExemptionApprovalCount + pendingExemptionCount}件</Box>
+				</Paper>
+			</Box>
 		</Box>
 	)
 }

--- a/src/app/student/portal/top/page.tsx
+++ b/src/app/student/portal/top/page.tsx
@@ -1,9 +1,14 @@
 import dynamic from 'next/dynamic'
 import Loading from '../loading'
+import { Container } from '@mui/material'
 const Top = dynamic(() => import('./_components/Top'), {
 	loading: () => <Loading />,
 })
 
 export default async function Page() {
-	return <Top />
+	return (
+		<Container>
+			<Top />
+		</Container>
+	)
 }

--- a/src/app/teacher/portal/account_setting/_components/AccountSetting.tsx
+++ b/src/app/teacher/portal/account_setting/_components/AccountSetting.tsx
@@ -18,5 +18,9 @@ export default async function AccountSetting() {
 	})
 
 	const teacherInfoData: Teacher[] = await teacherInfoResponse.json()
-	return <AccountSettingContents teacher={teacherInfoData[0]} />
+	const teacherData = teacherInfoData.find((teacher) => teacher.email === session.user.email)
+	if (!teacherData) {
+		redirect('/teacher/portal/top')
+	}
+	return <AccountSettingContents teacher={teacherData} />
 }

--- a/src/app/teacher/portal/top/_components/CardContents.tsx
+++ b/src/app/teacher/portal/top/_components/CardContents.tsx
@@ -1,0 +1,54 @@
+import { Box, Paper, SvgIconTypeMap } from '@mui/material'
+import { OverridableComponent } from '@mui/material/OverridableComponent'
+import Link from 'next/link'
+
+interface Props {
+	title: string
+	icon: OverridableComponent<SvgIconTypeMap<{}, 'svg'>> & {
+		muiName: string
+	}
+	url: string
+}
+
+export const CardContents = (props: Props) => {
+	return (
+		<Link
+			href={`/teacher/portal/${props.url}`}
+			style={{
+				width: 'fit-content',
+				textDecoration: 'none',
+			}}
+			prefetch={true}
+		>
+			<Paper
+				sx={{
+					width: '100px',
+					padding: '10px',
+				}}
+			>
+				<Box
+					sx={{
+						display: 'flex',
+						flexDirection: 'column',
+						alignItems: 'center',
+					}}
+				>
+					<Box
+						sx={{
+							fontSize: '24px',
+						}}
+					>
+						<props.icon
+							sx={{
+								fontSize: '50px',
+							}}
+						/>
+					</Box>
+					<Box>
+						<Box>{props.title}</Box>
+					</Box>
+				</Box>
+			</Paper>
+		</Link>
+	)
+}

--- a/src/app/teacher/portal/top/_components/TopContents.tsx
+++ b/src/app/teacher/portal/top/_components/TopContents.tsx
@@ -1,7 +1,110 @@
 import Box from '@mui/material/Box'
+import FormatListNumberedIcon from '@mui/icons-material/FormatListNumbered'
+import SaveAltIcon from '@mui/icons-material/SaveAlt'
+import BeenhereIcon from '@mui/icons-material/Beenhere'
+import NotificationsActiveIcon from '@mui/icons-material/NotificationsActive'
+import ManageHistoryIcon from '@mui/icons-material/ManageHistory'
+import { CardContents } from './CardContents'
 
-// TODO: 承認待ちの課題表紙総数を表示(要対応な情報を表示)
+const assignmentCardContents = [
+	{
+		title: '課題一覧',
+		icon: FormatListNumberedIcon,
+		url: 'assignment_list',
+	},
+	{
+		title: '課題登録',
+		icon: SaveAltIcon,
+		url: 'assignment_register',
+	},
+	{
+		title: '課題表紙承認',
+		icon: BeenhereIcon,
+		url: 'approve_assignment',
+	},
+]
+
+const notifyCardContents = [
+	{
+		title: '通知登録',
+		icon: NotificationsActiveIcon,
+		url: 'notification_register',
+	},
+]
+
+const classCardContents = [
+	{
+		title: 'クラス管理',
+		icon: ManageHistoryIcon,
+		url: 'class_management',
+	},
+	{
+		title: '課題免除許可',
+		icon: BeenhereIcon,
+		url: 'exemption_approval',
+	},
+]
 
 export const TopContents = () => {
-	return <Box>aaa</Box>
+	return (
+		<Box>
+			<Box
+				sx={{
+					fontSize: '20px',
+					py: '10px',
+				}}
+			>
+				課題表紙作業
+			</Box>
+			<Box
+				sx={{
+					display: 'flex',
+					flexWrap: 'wrap',
+					gap: '10px',
+				}}
+			>
+				{assignmentCardContents.map((content, index) => (
+					<CardContents key={index} {...content} />
+				))}
+			</Box>
+			<Box
+				sx={{
+					fontSize: '20px',
+					py: '10px',
+				}}
+			>
+				通知登録
+			</Box>
+			<Box
+				sx={{
+					display: 'flex',
+					flexWrap: 'wrap',
+					gap: '10px',
+				}}
+			>
+				{notifyCardContents.map((content, index) => (
+					<CardContents key={index} {...content} />
+				))}
+			</Box>
+			<Box
+				sx={{
+					fontSize: '20px',
+					py: '10px',
+				}}
+			>
+				担任クラスの管理
+			</Box>
+			<Box
+				sx={{
+					display: 'flex',
+					flexWrap: 'wrap',
+					gap: '10px',
+				}}
+			>
+				{classCardContents.map((content, index) => (
+					<CardContents key={index} {...content} />
+				))}
+			</Box>
+		</Box>
+	)
 }

--- a/src/app/teacher/signup/_components/SignUp.tsx
+++ b/src/app/teacher/signup/_components/SignUp.tsx
@@ -18,10 +18,10 @@ export default async function SignUp() {
 		},
 	})
 
-	const studentExists: TeacherExists = await res.json()
+	const teacherExists: TeacherExists = await res.json()
 
-	if (studentExists.exists) {
-		redirect('/teacher/portal')
+	if (teacherExists.exists) {
+		redirect('/teacher/portal/top')
 	}
 
 	const classListResponse = await fetch(`${process.env.API_URL}/api/teacher/class`, {

--- a/src/types/api-response-types.ts
+++ b/src/types/api-response-types.ts
@@ -246,3 +246,19 @@ export interface TeacherSubject {
 	subject_id: number
 	subject_name: string
 }
+
+export interface IssueCoverStatusCount {
+	issue_cover_status_count: {
+		total: number
+		pending?: number
+		rejected?: number
+		resubmission?: number
+		approved?: number
+		pending_absence?: number
+		absence?: number
+		pending_exemption_approval?: number
+		pending_exemption?: number
+		exemption?: number
+		late_pending?: number
+	}
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
	- 学生用ドロワーメニューから「課題」メニュー項目のみを表示するように変更しました。
	- 教師用ドロワーにプリフェッチ機能を追加しました。
	- クリック可能なカードを表示する新しい`CardContents`コンポーネントを学生と教師のポータルに追加しました。
	- 学生のトップページに課題の状態カウントを表示する機能を追加しました。
	- 教師のアカウント設定で、教師のデータが存在しない場合にトップページへのリダイレクトを行うように変更しました。
	- 教師のサインアップ時の変数名を修正し、リダイレクトパスを更新しました。

- **バグ修正**
	- 特になし

- **ドキュメント**
	- 特になし

- **リファクタリング**
	- 教師と学生のポータルトップコンポーネントのレイアウトとスタイリングを更新しました。

- **スタイル**
	- 特になし

- **テスト**
	- 特になし

- **チョア**
	- 特になし

- **リバート**
	- 特になし

<!-- end of auto-generated comment: release notes by coderabbit.ai -->