### PR TITLE
feat: 遅れ承認待ちを一括処理可能にする

### DIFF
--- a/src/app/teacher/portal/approve_assignment/_components/CollectiveOperation.tsx
+++ b/src/app/teacher/portal/approve_assignment/_components/CollectiveOperation.tsx
@@ -33,7 +33,8 @@ export const CollectiveOperation = ({
 						(issueCover) =>
 							issueCover.status === 'pending' ||
 							issueCover.status === 'resubmission' ||
-							issueCover.status === 'rejected',
+							issueCover.status === 'rejected' ||
+							issueCover.status === 'late_pending',
 					) ||
 					issueCoverData.some((issueCover) => issueCover.status === 'not_submitted')
 				}
@@ -53,7 +54,8 @@ export const CollectiveOperation = ({
 						(issueCover) =>
 							issueCover.status === 'pending' ||
 							issueCover.status === 'rejected' ||
-							issueCover.status === 'resubmission',
+							issueCover.status === 'resubmission' ||
+							issueCover.status === 'late_pending',
 					) ||
 					issueCoverData.some((issueCover) => issueCover.status === 'not_submitted')
 				}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
	- 教師ポータルの課題承認機能において、既存の`'pending'`（保留中）、`'resubmission'`（再提出）、`'rejected'`（拒否）、`'not_submitted'`（未提出）のステータスに加えて、`'late_pending'`（遅延保留中）の扱いが追加されました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->